### PR TITLE
Request optimisation

### DIFF
--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use futures::future::join_all;
 use octocrab::models::repos;
 use octocrab::repos::RepoHandler;
@@ -27,6 +25,7 @@ pub enum FetcherError {
     ReqwestError(reqwest::Error),
     InvalidSha256(usize),
     WrongChecksum,
+    NoReleaseFound,
 }
 
 impl Fetcher {
@@ -49,7 +48,7 @@ impl Fetcher {
         self.octocrab.repos(repo.owner(), repo.repository())
     }
 
-    pub async fn get_game_releases(&self) -> Result<Vec<GameRelease>> {
+    pub async fn get_latest_game_release(&self) -> Result<GameRelease> {
         let releases = self
             .on_repo(&self.game_repo)
             .releases()
@@ -57,50 +56,56 @@ impl Fetcher {
             .send()
             .await?;
 
-        let versions_released = releases
+        let mut versions_released = releases
             .into_iter()
-            .rev()
             .filter(|r| !r.prerelease)
             .filter_map(|r| Version::parse(&r.tag_name).ok().map(|v| (v, r)));
 
-        let mut game_releases = Vec::new();
         let mut latest_assets = None;
 
-        for (version, release) in versions_released {
-            let mut binaries = HashMap::new();
+        let Some((latest_version, latest_release)) = versions_released.next() else {
+            return Err(FetcherError::NoReleaseFound);
+        };
 
-            let assets_and_checksums = self.get_assets_and_checksums(release).await;
-
-            for (mut asset, checksum) in assets_and_checksums {
+        let binaries = self
+            .get_assets_and_checksums(&latest_release.assets)
+            .await
+            .map(|(mut asset, checksum)| {
                 asset.checksum = match checksum {
                     Ok(checksum) => Some(checksum),
                     Err(FetcherError::ReqwestError(_)) => None,
                     Err(err) => return Err(err),
                 };
 
-                let platform = remove_game_suffix(&asset.name);
-                if platform == "assets" {
+                Ok((remove_game_suffix(asset.name.as_str()).to_string(), asset))
+            })
+            .collect::<Result<Assets>>()?;
+
+        'outer: for (version, release) in versions_released {
+            for asset in release.assets {
+                if remove_game_suffix(asset.name.as_str()) == "assets" {
+                    let mut asset = Asset::from(&asset);
+                    asset.checksum = match self.checksum_fetcher.resolve(&asset).await {
+                        Ok(checksum) => Some(checksum),
+                        Err(FetcherError::ReqwestError(_)) => None,
+                        Err(err) => return Err(err),
+                    };
+
                     latest_assets = Some((version.clone(), asset));
-                } else {
-                    binaries.insert(platform.to_string(), asset);
+                    break 'outer;
                 }
             }
-
-            let Some((assets_version, assets)) = latest_assets.as_ref() else {
-                // if we don't have assets URL/versions yet we must skip
-                eprintln!("ignoring release {version} because no assets was found");
-                continue;
-            };
-
-            game_releases.push(GameRelease {
-                assets: assets.clone(),
-                assets_version: assets_version.clone(),
-                binaries,
-                version,
-            });
         }
 
-        Ok(game_releases)
+        match latest_assets {
+            Some((assets_version, assets)) => Ok(GameRelease {
+                assets,
+                assets_version,
+                binaries,
+                version: latest_version,
+            }),
+            None => Err(FetcherError::NoReleaseFound),
+        }
     }
 
     pub async fn get_latest_updater_release(&self) -> Result<Assets> {
@@ -110,30 +115,29 @@ impl Fetcher {
             .get_latest()
             .await?;
 
-        let mut binaries = HashMap::new();
+        self.get_assets_and_checksums(&last_release.assets)
+            .await
+            .map(|(mut asset, checksum)| {
+                asset.checksum = match checksum {
+                    Ok(checksum) => Some(checksum),
+                    Err(FetcherError::ReqwestError(_)) => None,
+                    Err(err) => return Err(err),
+                };
 
-        let assets_and_checksums = self.get_assets_and_checksums(last_release).await;
-
-        for (mut asset, checksum) in assets_and_checksums {
-            asset.checksum = match checksum {
-                Ok(checksum) => Some(checksum),
-                Err(FetcherError::ReqwestError(_)) => None,
-                Err(err) => return Err(err),
-            };
-
-            binaries.insert(remove_game_suffix(asset.name.as_str()).to_string(), asset);
-        }
-
-        Ok(binaries)
+                Ok((remove_game_suffix(asset.name.as_str()).to_string(), asset))
+            })
+            .collect::<Result<Assets>>()
     }
 
-    async fn get_assets_and_checksums(
+    async fn get_assets_and_checksums<'a, 'b, A>(
         &self,
-        release: repos::Release,
-    ) -> impl Iterator<Item = (Asset, Result<String>)> {
-        let assets = release
-            .assets
-            .iter()
+        assets: A,
+    ) -> impl Iterator<Item = (Asset, Result<String>)>
+    where
+        A: IntoIterator<Item = &'a repos::Asset>,
+    {
+        let assets = assets
+            .into_iter()
             .filter_map(|asset| {
                 match asset.name.ends_with(".sha256") {
                     false => Some(Asset::from(asset)),

--- a/src/game_data.rs
+++ b/src/game_data.rs
@@ -19,11 +19,13 @@ pub struct Repo {
     repository: String,
 }
 
+pub type Assets = HashMap<String, Asset>;
+
 #[derive(Clone)]
 pub struct GameRelease {
     pub assets: Asset,
     pub assets_version: Version,
-    pub binaries: HashMap<String, Asset>,
+    pub binaries: Assets,
     pub version: Version,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,16 +45,27 @@ async fn game_version(
     let mut cache = cache.lock().unwrap();
 
     // TODO: remove .cloned
-    let Ok(CachedReleased::Updater(updater_releases)) = cache.try_get_or_set_with("updater_releases", || async {
-        fetcher.get_updater_releases().await.map(CachedReleased::Updater)
-    }).await.cloned() else {
+    let Ok(CachedReleased::Updater(updater_releases)) = cache
+        .try_get_or_set_with("latest_updater_release", || async {
+            fetcher
+                .get_latest_updater_release()
+                .await
+                .map(CachedReleased::Updater)
+        })
+        .await
+        .cloned()
+    else {
         return HttpResponse::InternalServerError().finish();
     };
 
     // TODO: remove .cloned
-    let Ok(CachedReleased::Game(game_releases)) = cache.try_get_or_set_with("game_releases", || async {
-        fetcher.get_game_releases().await.map(CachedReleased::Game)
-    }).await.cloned() else {
+    let Ok(CachedReleased::Game(game_releases)) = cache
+        .try_get_or_set_with("game_releases", || async {
+            fetcher.get_game_releases().await.map(CachedReleased::Game)
+        })
+        .await
+        .cloned()
+    else {
         return HttpResponse::InternalServerError().finish();
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ struct AppData {
 #[derive(Clone)]
 enum CachedReleased {
     Updater(HashMap<String, Asset>),
-    Game(Vec<GameRelease>),
+    Game(GameRelease),
 }
 
 #[get("/game_version")]
@@ -45,7 +45,7 @@ async fn game_version(
     let mut cache = cache.lock().unwrap();
 
     // TODO: remove .cloned
-    let Ok(CachedReleased::Updater(updater_releases)) = cache
+    let Ok(CachedReleased::Updater(updater_release)) = cache
         .try_get_or_set_with("latest_updater_release", || async {
             fetcher
                 .get_latest_updater_release()
@@ -59,9 +59,12 @@ async fn game_version(
     };
 
     // TODO: remove .cloned
-    let Ok(CachedReleased::Game(game_releases)) = cache
-        .try_get_or_set_with("game_releases", || async {
-            fetcher.get_game_releases().await.map(CachedReleased::Game)
+    let Ok(CachedReleased::Game(game_release)) = cache
+        .try_get_or_set_with("latest_game_release", || async {
+            fetcher
+                .get_latest_game_release()
+                .await
+                .map(CachedReleased::Game)
         })
         .await
         .cloned()
@@ -69,32 +72,23 @@ async fn game_version(
         return HttpResponse::InternalServerError().finish();
     };
 
-    let updater_filename = format!("{}_{}", &ver_query.platform, config.updater_filename);
-    let game_release = game_releases.into_iter().rev().find_map(|release| {
-        let updater_release = updater_releases.get(&updater_filename)?;
+    let updater_filename = format!("{}_{}", ver_query.platform, config.updater_filename);
 
-        release
-            .binaries
-            .get(&ver_query.platform)
-            .map(|binaries| GameVersion {
-                assets: release.assets,
-                assets_version: release.assets_version.to_string(),
-                binaries: binaries.clone(),
-                updater: updater_release.clone(),
-                version: release.version.to_string(),
-            })
-    });
+    let (Some(updater), Some(binary)) = (updater_release.get(&updater_filename), game_release.binaries.get(&ver_query.platform)) else {
+        eprintln!(
+            "no updater or game binary release found for platform {}",
+            ver_query.platform
+        );
+        return HttpResponse::NotFound().finish();
+    };
 
-    match game_release {
-        Some(response) => HttpResponse::Ok().json(web::Json(response)),
-        None => {
-            eprintln!(
-                "no updater release found for platform {}",
-                ver_query.platform
-            );
-            HttpResponse::NotFound().finish()
-        }
-    }
+    HttpResponse::Ok().json(web::Json(GameVersion {
+        assets: game_release.assets,
+        assets_version: game_release.assets_version.to_string(),
+        binaries: binary.clone(),
+        updater: updater.clone(),
+        version: game_release.version.to_string(),
+    }))
 }
 
 #[actix_web::main]


### PR DESCRIPTION
Get the latest version of the game and assets without having to check everything

- move `assets_and_checksums` into a function
- rename `get_updater_releases` and `get_game_releases` into `get_latest_updater_release` and  `get_latest_game_release`
- and merging on_repo functions