### PR TITLE
Refactor the fix for assets not searched in latest release

### DIFF
--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -26,6 +26,7 @@ pub enum FetcherError {
     InvalidSha256(usize),
     WrongChecksum,
     NoReleaseFound,
+    InvalidVersion,
 }
 
 impl Fetcher {
@@ -66,49 +67,40 @@ impl Fetcher {
         };
 
         let mut binaries = self
-            .get_assets_and_checksums(&latest_release.assets)
+            .get_assets_and_checksums(&latest_release.assets, &latest_version, None)
             .await
-            .map(|(mut asset, checksum)| {
+            .map(|((platform, mut asset), checksum)| {
                 asset.checksum = match checksum {
                     Ok(checksum) => Some(checksum),
                     Err(FetcherError::ReqwestError(_)) => None,
                     Err(err) => return Err(err),
                 };
 
-                Ok((remove_game_suffix(asset.name.as_str()).to_string(), asset))
+                Ok((platform.to_string(), asset))
             })
             .collect::<Result<Assets>>()?;
 
-        let latest_assets = match binaries.remove("assets") {
-            Some(asset) => Some((latest_version.clone(), asset)),
-            None => 'blk: {
-                let versions_assets = versions_released.flat_map(|(version, release)| {
-                    release
-                        .assets
-                        .into_iter()
-                        .map(move |asset| (version.clone(), asset))
-                });
-                for (version, asset) in versions_assets {
-                    if remove_game_suffix(asset.name.as_str()) == "assets" {
-                        let mut asset = Asset::from(&asset);
-                        asset.checksum = match self.checksum_fetcher.resolve(&asset).await {
-                            Ok(checksum) => Some(checksum),
-                            Err(FetcherError::ReqwestError(_)) => None,
-                            Err(err) => return Err(err),
-                        };
+        for (version, release) in versions_released {
+            for ((platform, mut asset), checksum) in self
+                .get_assets_and_checksums(&release.assets, &version, Some(&binaries))
+                .await
+            {
+                asset.checksum = match checksum {
+                    Ok(checksum) => Some(checksum),
+                    Err(FetcherError::ReqwestError(_)) => None,
+                    Err(err) => return Err(err),
+                };
 
-                        break 'blk Some((version, asset));
-                    }
-                }
-
-                None
+                binaries.insert(platform.to_string(), asset);
             }
-        };
+        }
+
+        let latest_assets = binaries.remove("assets");
 
         match latest_assets {
-            Some((assets_version, assets)) => Ok(GameRelease {
+            Some(assets) => Ok(GameRelease {
+                assets_version: assets.version.clone(),
                 assets,
-                assets_version,
                 binaries,
                 version: latest_version,
             }),
@@ -123,42 +115,48 @@ impl Fetcher {
             .get_latest()
             .await?;
 
-        self.get_assets_and_checksums(&last_release.assets)
+        let version = Version::parse(&last_release.tag_name)?;
+
+        self.get_assets_and_checksums(&last_release.assets, &version, None)
             .await
-            .map(|(mut asset, checksum)| {
+            .map(|((platform, mut asset), checksum)| {
                 asset.checksum = match checksum {
                     Ok(checksum) => Some(checksum),
                     Err(FetcherError::ReqwestError(_)) => None,
                     Err(err) => return Err(err),
                 };
 
-                Ok((remove_game_suffix(asset.name.as_str()).to_string(), asset))
+                Ok((platform.to_string(), asset))
             })
             .collect::<Result<Assets>>()
     }
 
-    async fn get_assets_and_checksums<'a, 'b, A>(
+    async fn get_assets_and_checksums<'a: 'b, 'b, A>(
         &self,
         assets: A,
-    ) -> impl Iterator<Item = (Asset, Result<String>)>
+        version: &Version,
+        binaries: Option<&Assets>,
+    ) -> impl Iterator<Item = ((&'b str, Asset), Result<String>)>
     where
         A: IntoIterator<Item = &'a repos::Asset>,
     {
         let assets = assets
             .into_iter()
             .filter_map(|asset| {
-                match asset.name.ends_with(".sha256") {
-                    false => Some(Asset::from(asset)),
-                    // sha256 files ignored, they will be searched by the ChecksumFetcher
-                    true => None,
+                let platform = remove_game_suffix(asset.name.as_str());
+                match !asset.name.ends_with(".sha256")
+                    && !binaries.is_some_and(|b| b.contains_key(platform))
+                {
+                    true => Some((platform, Asset::with_version(asset, version.clone()))),
+                    false => None,
                 }
             })
-            .collect::<Vec<Asset>>();
+            .collect::<Vec<(&str, Asset)>>();
 
         let checksums = join_all(
             assets
                 .iter()
-                .map(|asset| self.checksum_fetcher.resolve(asset)),
+                .map(|(_, asset)| self.checksum_fetcher.resolve(asset)),
         )
         .await;
 
@@ -205,6 +203,12 @@ impl From<octocrab::Error> for FetcherError {
 impl From<reqwest::Error> for FetcherError {
     fn from(err: reqwest::Error) -> Self {
         FetcherError::ReqwestError(err)
+    }
+}
+
+impl From<semver::Error> for FetcherError {
+    fn from(_: semver::Error) -> Self {
+        FetcherError::InvalidVersion
     }
 }
 

--- a/src/game_data.rs
+++ b/src/game_data.rs
@@ -10,6 +10,8 @@ pub struct Asset {
     // serialisation skipped to race with the previous api
     #[serde(skip_serializing)]
     pub name: String,
+    #[serde(skip_serializing)]
+    pub version: Version,
     pub download_url: String,
     pub checksum: Option<String>,
 }
@@ -38,13 +40,14 @@ pub struct GameVersion {
     pub version: String,
 }
 
-impl From<&repos::Asset> for Asset {
-    fn from(asset: &repos::Asset) -> Self {
+impl Asset {
+    pub fn with_version(asset: &repos::Asset, version: Version) -> Self {
         Self {
             size: asset.size,
             name: asset.name.clone(),
             download_url: asset.browser_download_url.to_string(),
             checksum: None,
+            version,
         }
     }
 }


### PR DESCRIPTION
Use the fact that `binaries` has all the assets in the latest release and try to remove it (to get the owned value and avoid cloning), if the release doesn't have the assets, do as before.